### PR TITLE
Returning errors to frontend for environment form

### DIFF
--- a/scigym/environments/serializers.py
+++ b/scigym/environments/serializers.py
@@ -1,10 +1,13 @@
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError, _get_error_details
 from .models import Environment, Topic
+import logging
 
 from scigym.users.serializers import UserSerializer
 from scigym.repositories.serializers import RepositorySerializer
 from scigym.images.serializers import ImageSerializer
 
+logger = logging.getLogger('django')
 
 class TopicSerializer(serializers.ModelSerializer):
 
@@ -30,3 +33,55 @@ class EnvironmentWriteSerializer(serializers.ModelSerializer):
         model = Environment
         depth = 1
         fields = ('id', 'name', 'description', 'repository', 'tags', 'topic', 'current_avatar')
+
+class EnvironmentFormSerializer(serializers.ModelSerializer):
+
+    def is_valid_form(self, raise_exception=False):
+        """
+        The same as `.is_valid()` but with any error `code='unique'` removed.
+        This is used to validate data that is being edited.
+        """
+        assert not hasattr(self, 'restore_object'), (
+            'Serializer `%s.%s` has old-style version 2 `.restore_object()` '
+            'that is no longer compatible with REST framework 3. '
+            'Use the new-style `.create()` and `.update()` methods instead.' %
+            (self.__class__.__module__, self.__class__.__name__)
+        )
+
+        assert hasattr(self, 'initial_data'), (
+            'Cannot call `.is_valid()` as no `data=` keyword argument was '
+            'passed when instantiating the serializer instance.'
+        )
+
+        if not hasattr(self, '_validated_data'):
+            try:
+                self._validated_data = self.run_validation(self.initial_data)
+            except ValidationError as exc:
+                self._validated_data = {}
+                self._errors = exc.detail
+            else:
+                self._errors = {}
+
+        self._remove_errors()
+
+        if self._errors and raise_exception:
+            raise ValidationError(self.errors)
+
+        return not bool(self._errors)
+    
+    def _remove_errors(self):
+        """
+        Removes errors of type `code='unique'` from specified errors.
+
+        TODO: Use code.
+        """
+        if 'name' in self.errors.keys():
+            for error in self.errors['name']:
+                if error == 'environment with this name already exists.':
+                    error_detail = self._errors.pop('name')
+                    logger.info(f'Removing some `unique` errors: {error_detail}')
+
+    class Meta:
+        model = Environment
+        depth = 1
+        fields = ('id', 'name', 'description', 'tags', 'topic', 'current_avatar')

--- a/scigym/environments/serializers.py
+++ b/scigym/environments/serializers.py
@@ -36,51 +36,6 @@ class EnvironmentWriteSerializer(serializers.ModelSerializer):
 
 class EnvironmentFormSerializer(serializers.ModelSerializer):
 
-    def is_valid_form(self, raise_exception=False):
-        """
-        The same as `.is_valid()` but with any error `code='unique'` removed.
-        This is used to validate data that is being edited.
-        """
-        assert not hasattr(self, 'restore_object'), (
-            'Serializer `%s.%s` has old-style version 2 `.restore_object()` '
-            'that is no longer compatible with REST framework 3. '
-            'Use the new-style `.create()` and `.update()` methods instead.' %
-            (self.__class__.__module__, self.__class__.__name__)
-        )
-
-        assert hasattr(self, 'initial_data'), (
-            'Cannot call `.is_valid()` as no `data=` keyword argument was '
-            'passed when instantiating the serializer instance.'
-        )
-
-        if not hasattr(self, '_validated_data'):
-            try:
-                self._validated_data = self.run_validation(self.initial_data)
-            except ValidationError as exc:
-                self._validated_data = {}
-                self._errors = exc.detail
-            else:
-                self._errors = {}
-
-        self._remove_errors()
-
-        if self._errors and raise_exception:
-            raise ValidationError(self.errors)
-
-        return not bool(self._errors)
-    
-    def _remove_errors(self):
-        """
-        Removes errors of type `code='unique'` from specified errors.
-
-        TODO: Use code.
-        """
-        if 'name' in self.errors.keys():
-            for error in self.errors['name']:
-                if error == 'environment with this name already exists.':
-                    error_detail = self._errors.pop('name')
-                    logger.info(f'Removing some `unique` errors: {error_detail}')
-
     class Meta:
         model = Environment
         depth = 1

--- a/scigym/environments/views.py
+++ b/scigym/environments/views.py
@@ -52,8 +52,8 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
             'tags': request.data['tags'],
             'current_avatar': avatar
         }
-        serializer = EnvironmentFormSerializer(data=env_data)
-        if serializer.is_valid(raise_exception=False):
+        serializer = EnvironmentWriteSerializer(data=env_data)
+        if serializer.is_valid(raise_exception=True):
             env = Environment.objects.create(
                 name=env_data['name'],
                 description=env_data['description'],
@@ -67,11 +67,7 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
                 env.topic= Topic.objects.get(id=request.data['topic'])
                 env.save()
 
-            serializer = EnvironmentWriteSerializer(env)
             return Response(serializer.data, status=201)
-        else:
-            logger.info(serializer.errors)
-            raise ValidationError(serializer.errors)
     
     def update(self, request, pk):
         env =  get_object_or_404(Environment, pk=pk)
@@ -96,20 +92,11 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
         else:
             env_data['current_avatar'] = None
 
-        serializer = EnvironmentFormSerializer(data=env_data)
-        if serializer.is_valid_form(raise_exception=False):
-            env.name = env_data['name']
-            env.description = env_data['description']
-            env.tags = env_data['tags']
-            env.topic = env_data['topic']
-            env.current_avatar = env_data['current_avatar']
+        serializer = EnvironmentFormSerializer(env, data=env_data)
+        if serializer.is_valid(raise_exception=True):
 
-            env.save()
-            serializer = EnvironmentWriteSerializer(env)
+            serializer.save()
             return(Response(serializer.data, status=200))
-        else:
-            raise ValidationError(serializer.errors)
-
 
     @action(['GET'], detail=False)
     def filter(self, request):


### PR DESCRIPTION
This is the PR on the API for the corresponding [frontend PR](https://github.com/HendrikPN/scigym-web/pull/34). For errors to be displayed on the `EnvironmentForm`, the backend now provides `exceptions`.